### PR TITLE
Added Implementations to Wordmodel and Levels

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -20,23 +20,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (3)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>1.8</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/src/VoxspellApp/InitialScene.java
+++ b/src/VoxspellApp/InitialScene.java
@@ -200,4 +200,6 @@ public class InitialScene {
         });
     }
 
+
+
 }

--- a/src/VoxspellApp/Voxspell.java
+++ b/src/VoxspellApp/Voxspell.java
@@ -33,6 +33,9 @@ public class Voxspell extends Application {
 
     Button playButton;
 
+    //GLOBAL VARIABLES
+    public static final int COUNT = 10;
+
     @Override
     public void start(Stage primaryStage) throws Exception{
         _mainWindow = primaryStage;

--- a/src/models/Level.java
+++ b/src/models/Level.java
@@ -1,8 +1,13 @@
 package models;
 
+
+import VoxspellApp.Voxspell;
+
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
 
 /**
  * Created by edson on 15/09/16.
@@ -27,4 +32,22 @@ public class Level implements Resettable{
         }
     }
 
+    /**
+     * This method shuffles the word list and returns a selected list of words. If there are
+     * less than 10 words in the list, the list is returned and a spelling quiz can be done
+     * with less than 10 words.
+     * @return List<Word>
+     */
+   public List<Word> getWords() {
+       Collections.shuffle(_wordList);
+       if (_wordList.size() < Voxspell.COUNT) {
+           return _wordList;
+       } else {
+           List<Word> selectedWords = new ArrayList<Word>(Voxspell.COUNT);
+           for (int i = 0; i < Voxspell.COUNT; i++) {
+               selectedWords.add(_wordList.get(i));
+           }
+           return selectedWords;
+       }
+   }
 }

--- a/src/models/Word.java
+++ b/src/models/Word.java
@@ -30,4 +30,17 @@ public class Word implements Resettable{
         _status = Status.Unseen;
     }
 
+    @Override
+    /**
+     * This method overrides the default equals method so that the words will be
+     * compared to their strings and not their actual objects
+     */
+    public boolean equals(Object object) {
+        if (object instanceof Word) {
+            return ((Word)object)._word.equals(this._word);
+        } else {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
WordModel needs access to current level and needs  a method that returns a list of words at that current level using the getWords method in the level class. This is done just by finding the level object that you are at and then doing level.getWords().
WordModel also needs to be accessed by spellingLogic as spellingLogic needs to call the above method to get the words. This means spellingLogic doesn't care about what level it is at, just the fact that it will get words.
